### PR TITLE
Allow blacklisting collectible items (raw meat, leathers, etc.)

### DIFF
--- a/1.4/Source/VanillaTradingExpanded/Misc/Contract.cs
+++ b/1.4/Source/VanillaTradingExpanded/Misc/Contract.cs
@@ -20,6 +20,7 @@ namespace VanillaTradingExpanded
         public Map mapToTakeItems;
         public string Name => "x" + BaseName;
         public string BaseName => amount + " " + ItemName;
+        private ThingCategoryDef[] blacklist = { ThingCategoryDefOf.EggsFertilized, ThingCategoryDefOf.EggsUnfertilized, ThingCategoryDefOf.MeatRaw, ThingCategoryDefOf.Leathers, ThingCategoryDefOf.Wools };
         public string ItemName
         {
             get
@@ -47,6 +48,10 @@ namespace VanillaTradingExpanded
                 tries++;
                 Reset();
                 item = Utils.craftableOrCollectableItems.RandomElement();
+                while (VanillaTradingExpandedMod.settings.contractBlackListCollectibles && item.thingCategories.Any(x => blacklist.Contains(x)))
+                {
+                    item = Utils.craftableOrCollectableItems.RandomElement();
+                }
                 stuff = GenStuff.RandomStuffFor(item);
                 amount = Mathf.Max(1, (int)(targetMarketValue.RandomInRange / item.GetStatValueAbstract(StatDefOf.MarketValue, stuff)));
                 if (targetMarketValue.Includes(BaseMarketValue))

--- a/1.4/Source/VanillaTradingExpanded/Settings.cs
+++ b/1.4/Source/VanillaTradingExpanded/Settings.cs
@@ -21,6 +21,7 @@ namespace VanillaTradingExpanded
         public int maxMarkupOnNPCContract = 10;
         public float newsPriceImpactMultiplier = 1f;
         public float amountOfItemsToFluctuate = 0.2f;
+        public bool contractBlackListCollectibles = false;
         public bool caravanLessContractItemPickup = false;
         public float maximumMarketValueOfItemsInContracts = 10000;
         public float maximumMarketValueOfItemsPerPlayerWealth = 0.01f;
@@ -39,6 +40,7 @@ namespace VanillaTradingExpanded
             Scribe_Values.Look(ref maxMarkupOnNPCContract, "maxMarkupOnNPCContract", 10);
             Scribe_Values.Look(ref newsPriceImpactMultiplier, "newsPriceImpactMultiplier", 1f);
             Scribe_Values.Look(ref amountOfItemsToFluctuate, "itemsToFluctuate", 0.2f);
+            Scribe_Values.Look(ref contractBlackListCollectibles, "contractBlackListCollectibles", false);
             Scribe_Values.Look(ref caravanLessContractItemPickup, "caravanLessContractItemPickup", false);
             Scribe_Values.Look(ref maximumMarketValueOfItemsInContracts, "maximumMarketValueOfItemsInContracts", 10000);
             Scribe_Values.Look(ref maximumMarketValueOfItemsPerPlayerWealth, "maximumMarketValueOfItemsPerPlayerWealth", 0.01f);
@@ -128,6 +130,7 @@ namespace VanillaTradingExpanded
             buf1 = settings.maximumMarketValueOfItemsInContracts.ToString();
             Widgets.TextFieldNumeric(new Rect(inRect.width - 200, listingStandard.curY - 24, 200, 24), ref settings.maximumMarketValueOfItemsInContracts, ref buf1);
             listingStandard.SliderLabeled("VTE.MaximumMarketValueOfItemsPerPlayerWealth".Translate(), ref settings.maximumMarketValueOfItemsPerPlayerWealth, settings.maximumMarketValueOfItemsPerPlayerWealth.ToStringPercent());
+            listingStandard.CheckboxLabeled("VTE.ContractBlackListCollectibles".Translate(), ref settings.contractBlackListCollectibles);
             listingStandard.CheckboxLabeled("VTE.CaravanLessContractItemPickup".Translate(), ref settings.caravanLessContractItemPickup);
             listingStandard.SliderLabeled("VTE.AmountOfRandomItemsToFluctuate".Translate(), ref settings.amountOfItemsToFluctuate, ((float)(settings.amountOfItemsToFluctuate)).ToStringPercent(), 0.01f, 1f);
             if (Find.World != null)
@@ -152,6 +155,7 @@ namespace VanillaTradingExpanded
                 settings.maxMarkupOnNPCContract = 10;
                 settings.newsPriceImpactMultiplier = 1f;
                 settings.amountOfItemsToFluctuate = 0.2f;
+                settings.contractBlackListCollectibles = false;
                 settings.caravanLessContractItemPickup = false;
                 settings.maximumMarketValueOfItemsInContracts = 10000;
                 settings.maximumMarketValueOfItemsPerPlayerWealth = 0.01f;

--- a/Languages/English/Keyed/Keyed.xml
+++ b/Languages/English/Keyed/Keyed.xml
@@ -128,6 +128,7 @@ Cargo pods are arriving containing:
 	<VTE.AmountOfRandomItemsToFluctuate>Amount of random item price fluctuations:</VTE.AmountOfRandomItemsToFluctuate>
 	<VTE.ResetPriceChanges>Reset price fluctuations</VTE.ResetPriceChanges>
 	<VTE.YouCanTakeThisLoanOn>You can only take this loan again on {0}.</VTE.YouCanTakeThisLoanOn>
+	<VTE.ContractBlackListCollectibles>Blacklist collectibles (Eggs, Meat, Leather and Wool) for contracts</VTE.ContractBlackListCollectibles>
 	<VTE.CaravanLessContractItemPickup>Caravan-less contract item pickup</VTE.CaravanLessContractItemPickup>
 	<VTE.MaximumMarketValueOfItemsInContracts>Maximum value of NPC contracts in silver:</VTE.MaximumMarketValueOfItemsInContracts>
 	<VTE.MaximumMarketValueOfItemsPerPlayerWealth>Maximum value of NPC contracts in percentage of wealth:</VTE.MaximumMarketValueOfItemsPerPlayerWealth>


### PR DESCRIPTION
Late-game contracts often include stuff like "2200 Boomalope meat" and such, which makes fulfilling those contracts near impossible. This commit adds a config option that allows blacklisting collectible items (raw meat, leather, etc.) while generating contracts so that most contracts are approachable.