### PR TITLE
Cache solid Texture2D for background of taken loans

### DIFF
--- a/1.4/Source/VanillaTradingExpanded/UI/Window_Bank.cs
+++ b/1.4/Source/VanillaTradingExpanded/UI/Window_Bank.cs
@@ -253,8 +253,8 @@ namespace VanillaTradingExpanded
 			{
 				if (loanIsTaken)
                 {
-					GUI.DrawTexture(rect, SolidColorMaterials.NewSolidColorTexture(new ColorInt(22, 22, 22).ToColor));
-				}
+                    GUI.DrawTexture(rect, GuiHelper.LoanTakenTexture);
+                }
 				else
                 {
 					Widgets.DrawHighlight(rect);

--- a/1.4/Source/VanillaTradingExpanded/Utils/GuiHelper.cs
+++ b/1.4/Source/VanillaTradingExpanded/Utils/GuiHelper.cs
@@ -15,6 +15,7 @@ namespace VanillaTradingExpanded
 	public static class GuiHelper
 	{
 		public static readonly Texture2D ChartIcon = ContentFinder<Texture2D>.Get("UI/Chart");
+		public static readonly Texture2D LoanTakenTexture = SolidColorMaterials.NewSolidColorTexture(new ColorInt(22, 22, 22).ToColor);
 
 		private static readonly Rect DefaultTexCoords;
 		private static readonly Rect LinkedTexCoords;


### PR DESCRIPTION
Fixes the issue where the textures would get endlessly created and fill up RAM, similarly to the issue with VRE-Sanguophage mod.